### PR TITLE
feat: add Windows support

### DIFF
--- a/src/events/hook.rs
+++ b/src/events/hook.rs
@@ -1,7 +1,7 @@
 use super::AppEvent;
 use serde::{Deserialize, Serialize};
 use std::io::{BufRead, BufReader, Write};
-use std::os::unix::net::{UnixListener, UnixStream};
+use std::net::{TcpListener, TcpStream};
 use std::path::PathBuf;
 use std::thread;
 use tokio::sync::mpsc;
@@ -43,8 +43,8 @@ impl HookEvent {
 }
 
 #[must_use]
-pub fn get_socket_path() -> PathBuf {
-    std::env::temp_dir().join("chloe.sock")
+pub fn get_port_file_path() -> PathBuf {
+    std::env::temp_dir().join("chloe.port")
 }
 
 pub struct EventListener {
@@ -53,14 +53,12 @@ pub struct EventListener {
 
 impl EventListener {
     pub fn start(event_sender: Option<mpsc::UnboundedSender<AppEvent>>) -> std::io::Result<Self> {
-        let socket_path = get_socket_path();
-
-        if socket_path.exists() {
-            std::fs::remove_file(&socket_path)?;
-        }
-
-        let listener = UnixListener::bind(&socket_path)?;
+        let listener = TcpListener::bind("127.0.0.1:0")?;
+        let local_port = listener.local_addr()?.port();
         listener.set_nonblocking(true)?;
+
+        let port_file_path = get_port_file_path();
+        std::fs::write(&port_file_path, local_port.to_string())?;
 
         thread::spawn(move || {
             run_listener(&listener, event_sender.as_ref());
@@ -72,12 +70,12 @@ impl EventListener {
 
 impl Drop for EventListener {
     fn drop(&mut self) {
-        let socket_path = get_socket_path();
-        let _ = std::fs::remove_file(socket_path);
+        let port_file_path = get_port_file_path();
+        let _ = std::fs::remove_file(port_file_path);
     }
 }
 
-fn run_listener(listener: &UnixListener, event_sender: Option<&mpsc::UnboundedSender<AppEvent>>) {
+fn run_listener(listener: &TcpListener, event_sender: Option<&mpsc::UnboundedSender<AppEvent>>) {
     loop {
         match listener.accept() {
             Ok((stream, _)) => {
@@ -93,7 +91,7 @@ fn run_listener(listener: &UnixListener, event_sender: Option<&mpsc::UnboundedSe
     }
 }
 
-fn handle_connection(stream: UnixStream, event_sender: Option<&mpsc::UnboundedSender<AppEvent>>) {
+fn handle_connection(stream: TcpStream, event_sender: Option<&mpsc::UnboundedSender<AppEvent>>) {
     let Some(sender) = event_sender else {
         return;
     };
@@ -116,8 +114,14 @@ fn handle_connection(stream: UnixStream, event_sender: Option<&mpsc::UnboundedSe
 }
 
 pub fn send_event(event: &HookEvent) -> std::io::Result<()> {
-    let socket_path = get_socket_path();
-    let mut stream = UnixStream::connect(&socket_path)?;
+    let port_file_path = get_port_file_path();
+    let port_string = std::fs::read_to_string(&port_file_path)?;
+    let port: u16 = port_string
+        .trim()
+        .parse()
+        .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error))?;
+
+    let mut stream = TcpStream::connect(("127.0.0.1", port))?;
 
     let json = serde_json::to_string(event)
         .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error))?;

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -10,7 +10,7 @@ pub use crate::views::settings::SettingsAction;
 pub use crate::views::worktree::WorktreeAction;
 pub use app::AppEvent;
 pub use event_loop::EventLoop;
-pub use hook::{EventListener, EventType, HookEvent, get_socket_path, send_event};
+pub use hook::{EventListener, EventType, HookEvent, get_port_file_path, send_event};
 
 use crossterm::event::KeyEvent;
 

--- a/src/views/instances/operations.rs
+++ b/src/views/instances/operations.rs
@@ -314,9 +314,17 @@ fn build_shell_wrapped_command(
         full_command.push_str(&escape_shell_arg(arg));
     }
 
-    let shell_script = format!("{full_command}; exec $SHELL");
+    #[cfg(unix)]
+    {
+        let shell_script = format!("{full_command}; exec $SHELL");
+        ("bash".to_string(), vec!["-c".to_string(), shell_script])
+    }
 
-    ("bash".to_string(), vec!["-c".to_string(), shell_script])
+    #[cfg(windows)]
+    {
+        let shell_script = format!("{full_command} & cmd.exe");
+        ("cmd.exe".to_string(), vec!["/C".to_string(), shell_script])
+    }
 }
 
 fn escape_shell_arg(arg: &str) -> String {

--- a/src/views/instances/pty.rs
+++ b/src/views/instances/pty.rs
@@ -12,6 +12,9 @@ use std::time::Duration;
 use tokio::sync::mpsc;
 use uuid::Uuid;
 
+#[cfg(windows)]
+use alacritty_terminal::tty::{EventedPty, EventedReadWrite};
+
 const DEFAULT_SCROLLBACK_LINES: usize = 10000;
 const READ_BUFFER_BYTES: usize = 4096;
 const READ_POLL_DELAY_MS: u64 = 10;
@@ -43,7 +46,10 @@ impl EventListener for EventProxy {
 
 pub struct PtySession {
     term: Arc<Mutex<Term<EventProxy>>>,
+    #[cfg(unix)]
     pty: Pty,
+    #[cfg(windows)]
+    pty: Arc<Mutex<Pty>>,
 }
 
 pub struct SpawnOptions {
@@ -126,6 +132,8 @@ impl PtySession {
             working_directory: Some(options.working_directory.clone()),
             env: options.environment.clone(),
             drain_on_exit: true,
+            #[cfg(windows)]
+            escape_args: false,
         };
 
         let window_size = WindowSize {
@@ -150,51 +158,27 @@ impl PtySession {
 
         let term = Arc::new(Mutex::new(term));
 
-        let reader = pty.file().try_clone()?;
         let pane_id = options.pane_id;
         let event_sender = options.event_sender;
-
         let term_for_thread = Arc::clone(&term);
 
-        thread::spawn(move || {
-            let mut reader = reader;
-            let mut buffer = [0u8; READ_BUFFER_BYTES];
-            let mut processor: Processor<StdSyncHandler> = Processor::new();
+        #[cfg(unix)]
+        {
+            let reader = pty.file().try_clone()?;
+            spawn_unix_reader_thread(reader, pane_id, event_sender, term_for_thread);
+            Ok(Self { term, pty })
+        }
 
-            loop {
-                match reader.read(&mut buffer) {
-                    Ok(0) => {
-                        let _ = event_sender.send(AppEvent::PtyExit { pane_id });
-                        break;
-                    }
-                    Ok(bytes_read) => {
-                        let data = buffer[..bytes_read].to_vec();
-
-                        if let Ok(mut term) = term_for_thread.lock() {
-                            processor.advance(&mut *term, &data);
-                        }
-
-                        if event_sender
-                            .send(AppEvent::PtyOutput { pane_id, data })
-                            .is_err()
-                        {
-                            break;
-                        }
-                    }
-                    Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
-                        thread::sleep(Duration::from_millis(READ_POLL_DELAY_MS));
-                    }
-                    Err(_) => {
-                        let _ = event_sender.send(AppEvent::PtyExit { pane_id });
-                        break;
-                    }
-                }
-            }
-        });
-
-        Ok(Self { term, pty })
+        #[cfg(windows)]
+        {
+            let pty = Arc::new(Mutex::new(pty));
+            let pty_for_thread = Arc::clone(&pty);
+            spawn_windows_reader_thread(pty_for_thread, pane_id, event_sender, term_for_thread);
+            Ok(Self { term, pty })
+        }
     }
 
+    #[allow(clippy::needless_pass_by_ref_mut)]
     pub fn resize(&mut self, rows: u16, columns: u16) {
         let window_size = WindowSize {
             cell_width: 1,
@@ -202,7 +186,14 @@ impl PtySession {
             num_cols: columns,
             num_lines: rows,
         };
+
+        #[cfg(unix)]
         self.pty.on_resize(window_size);
+
+        #[cfg(windows)]
+        if let Ok(mut pty) = self.pty.lock() {
+            pty.on_resize(window_size);
+        }
 
         if let Ok(mut term) = self.term.lock() {
             let term_size = TerminalSize {
@@ -219,11 +210,126 @@ impl PtySession {
     }
 
     pub fn write_input(&self, data: &[u8]) -> anyhow::Result<()> {
-        let mut writer = self.pty.file().try_clone()?;
-        writer.write_all(data)?;
-        writer.flush()?;
+        #[cfg(unix)]
+        {
+            let mut writer = self.pty.file().try_clone()?;
+            writer.write_all(data)?;
+            writer.flush()?;
+        }
+
+        #[cfg(windows)]
+        {
+            let mut pty = self
+                .pty
+                .lock()
+                .map_err(|error| anyhow::anyhow!("PTY lock poisoned: {error}"))?;
+            pty.writer().write_all(data)?;
+            pty.writer().flush()?;
+        }
+
         Ok(())
     }
+}
+
+#[cfg(unix)]
+fn spawn_unix_reader_thread(
+    reader: std::fs::File,
+    pane_id: Uuid,
+    event_sender: mpsc::UnboundedSender<AppEvent>,
+    term: Arc<Mutex<Term<EventProxy>>>,
+) {
+    thread::spawn(move || {
+        let mut reader = reader;
+        let mut buffer = [0u8; READ_BUFFER_BYTES];
+        let mut processor: Processor<StdSyncHandler> = Processor::new();
+
+        loop {
+            match reader.read(&mut buffer) {
+                Ok(0) => {
+                    let _ = event_sender.send(AppEvent::PtyExit { pane_id });
+                    break;
+                }
+                Ok(bytes_read) => {
+                    let data = buffer[..bytes_read].to_vec();
+
+                    if let Ok(mut term) = term.lock() {
+                        processor.advance(&mut *term, &data);
+                    }
+
+                    if event_sender
+                        .send(AppEvent::PtyOutput { pane_id, data })
+                        .is_err()
+                    {
+                        break;
+                    }
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                    thread::sleep(Duration::from_millis(READ_POLL_DELAY_MS));
+                }
+                Err(_) => {
+                    let _ = event_sender.send(AppEvent::PtyExit { pane_id });
+                    break;
+                }
+            }
+        }
+    });
+}
+
+#[cfg(windows)]
+fn spawn_windows_reader_thread(
+    pty: Arc<Mutex<Pty>>,
+    pane_id: Uuid,
+    event_sender: mpsc::UnboundedSender<AppEvent>,
+    term: Arc<Mutex<Term<EventProxy>>>,
+) {
+    thread::spawn(move || {
+        let mut buffer = [0u8; READ_BUFFER_BYTES];
+        let mut processor: Processor<StdSyncHandler> = Processor::new();
+
+        loop {
+            let read_result = {
+                let Ok(mut pty) = pty.lock() else {
+                    break;
+                };
+
+                if let Some(alacritty_terminal::tty::ChildEvent::Exited(_)) =
+                    pty.next_child_event()
+                {
+                    let _ = event_sender.send(AppEvent::PtyExit { pane_id });
+                    break;
+                }
+
+                pty.reader().read(&mut buffer)
+            };
+
+            match read_result {
+                Ok(0) => {
+                    thread::sleep(Duration::from_millis(READ_POLL_DELAY_MS));
+                }
+                Ok(bytes_read) => {
+                    let data = buffer[..bytes_read].to_vec();
+
+                    if let Ok(mut term) = term.lock() {
+                        processor.advance(&mut *term, &data);
+                    }
+
+                    if event_sender
+                        .send(AppEvent::PtyOutput { pane_id, data })
+                        .is_err()
+                    {
+                        break;
+                    }
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                    thread::sleep(Duration::from_millis(READ_POLL_DELAY_MS));
+                }
+                Err(_) => {
+                    let _ = event_sender.send(AppEvent::PtyExit { pane_id });
+                    break;
+                }
+            }
+        }
+    });
 }
 
 impl std::fmt::Debug for PtySession {


### PR DESCRIPTION
## Summary
- Replace Unix domain sockets with TCP localhost (`127.0.0.1:0`) for hook event IPC, making it cross-platform
- Add platform-specific PTY handling via `#[cfg]` gates — Unix keeps the file-clone approach, Windows uses `Arc<Mutex<Pty>>` with the `EventedReadWrite` trait
- Use `cmd.exe /C` for shell wrapping on Windows instead of `bash -c`

## Details

**`src/events/hook.rs`**: `UnixListener`/`UnixStream` → `TcpListener`/`TcpStream`. Binds to `127.0.0.1:0` (OS picks free port), writes port to `$TEMP/chloe.port`, reads it back on connect. No `#[cfg]` needed — TCP works everywhere.

**`src/views/instances/pty.rs`**: On Windows, `Pty` doesn't expose `file()`, so the PTY is wrapped in `Arc<Mutex<Pty>>` and read/write/resize go through the mutex. The Windows `UnblockedReader` is non-blocking (returns 0 immediately when no data), so the polling loop works well. Added `escape_args: false` to `Options` (Windows-only field).

**`src/views/instances/operations.rs`**: `build_shell_wrapped_command` uses `cmd.exe /C "{command} & cmd.exe"` on Windows.

## Test plan
- [x] `cargo check` passes on Windows
- [x] `cargo clippy` — no new warnings
- [x] `cargo build` — produces working binary
- [x] `cargo run` — TUI launches and renders correctly on Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)